### PR TITLE
Fixed Deprecation warning: Loop on installing pkgs

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,9 +1,8 @@
 ---
 - name: 'Installing APT dependencies'
   apt:
-    pkg: "{{ item }}"
+    pkg:
+      - unzip
+      - libwww-perl
+      - libdatetime-perl
     state: present
-  with_items:
-    - unzip
-    - libwww-perl
-    - libdatetime-perl

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -9,4 +9,3 @@
       - perl-LWP-Protocol-https
       - perl-Digest-SHA
     state: present
-  with_items:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,12 +1,12 @@
 ---
 - name: 'Installing YUM dependencies'
   yum:
-    pkg: "{{ item }}"
+    pkg:
+      - zip
+      - unzip
+      - perl-DateTime
+      - perl-Sys-Syslog
+      - perl-LWP-Protocol-https
+      - perl-Digest-SHA
     state: present
   with_items:
-    - zip
-    - unzip
-    - perl-DateTime
-    - perl-Sys-Syslog
-    - perl-LWP-Protocol-https
-    - perl-Digest-SHA


### PR DESCRIPTION
Now using `with_items` with `apt` or `yum` packages is deprecated
(I found it on ansible: 2.9.1).

```
TASK [Restless-ET.aws-scripts-mon : Installing APT dependencies] ***************

[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `pkg: "{{ item }}"`, please use `pkg: ['unzip', 'libwww-perl',
'libdatetime-perl']` and remove the loop. This feature will be removed in
version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.

changed: [127.0.0.1] => (item=[u'unzip', u'libwww-perl', u'libdatetime-perl'])

TASK [Restless-ET.aws-scripts-mon : Installing YUM dependencies] ***************

[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `pkg: "{{ item }}"`, please use `pkg: ['zip', 'unzip', 'perl-
DateTime', 'perl-Sys-Syslog', 'perl-LWP-Protocol-https', 'perl-Digest-SHA']`
and remove the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```